### PR TITLE
PHP 8.5 support, CI improvements, and test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,15 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build-test:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
-    name: PHP ${{ matrix.php-versions }} Test
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+    name: PHP ${{ matrix.php-version }} Test
     services:
       redis:
         image: redis
@@ -22,30 +22,30 @@ jobs:
           - 6379:6379
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: :redis
+          php-version: ${{ matrix.php-version }}
+          extensions: pcntl, sysvshm, sysvsem, sysvmsg, redis
+          coverage: ${{ matrix.php-version == '8.5' && 'xdebug' || 'none' }}
 
-      - name: Install composer and dependencies
-        uses: php-actions/composer@v6
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
 
-      - name: PHPUnit Tests
-        uses: php-actions/phpunit@v3
-        env:
-          XDEBUG_MODE: coverage
-        with:
-          bootstrap: vendor/autoload.php
-          configuration: phpunit.xml
-          php_extensions: xdebug sysvshm pcntl sysvsem sysvmsg redis
-          version: 9
-          args: tests --coverage-clover ./coverage.xml
+      - name: Run tests (with coverage)
+        if: matrix.php-version == '8.5'
+        run: |
+          XDEBUG_MODE=coverage vendor/bin/phpunit --configuration phpunit.xml --coverage-clover ./coverage.xml
+
+      - name: Run tests
+        if: matrix.php-version != '8.5'
+        run: vendor/bin/phpunit --configuration phpunit.xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        if: matrix.php-version == '8.5'
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     name: PHP ${{ matrix.php-versions }} Test
     services:
       redis:

--- a/src/Lock/Semaphore.php
+++ b/src/Lock/Semaphore.php
@@ -15,6 +15,7 @@ namespace Jenner\SimpleFork\Lock;
  */
 class Semaphore implements LockInterface
 {
+	/** @var false|resource|\SysvSemaphore */
     private $lock_id;
 
     /**
@@ -151,6 +152,13 @@ class Semaphore implements LockInterface
         if ($this->locked) {
             throw new \RuntimeException('can not remove a locked semaphore resource');
         }
-        throw new \RuntimeException('can not remove a empty semaphore resource');
-    }
+
+		if (is_resource($this->lock_id) || $this->lock_id instanceof \SysvSemaphore) {
+			$result = sem_remove($this->lock_id);
+			$this->lock_id = null;
+			return $result;
+		}
+
+		throw new \RuntimeException('can not remove a empty semaphore resource');
+	}
 }

--- a/src/Lock/Semaphore.php
+++ b/src/Lock/Semaphore.php
@@ -151,17 +151,6 @@ class Semaphore implements LockInterface
         if ($this->locked) {
             throw new \RuntimeException('can not remove a locked semaphore resource');
         }
-        if (!is_resource($this->lock_id)) {
-            throw new \RuntimeException('can not remove a empty semaphore resource');
-        }
-
-        // @codeCoverageIgnoreStart
-        // seems impossible to reproduce further below
-        if (!sem_release($this->lock_id)) {
-            return false;
-        }
-
-        return true;
-        // @codeCoverageIgnoreEnd
+        throw new \RuntimeException('can not remove a empty semaphore resource');
     }
 }

--- a/src/Process.php
+++ b/src/Process.php
@@ -75,7 +75,7 @@ class Process
      * @param string|callable|null $execution it can be a Runnable object, callback function or null
      * @param string|null $name process name,you can manager the process by it's name.
      */
-    public function __construct($execution = null, string $name = null)
+    public function __construct($execution = null, ?string $name = null)
     {
         if ($execution instanceof Runnable) {
             $this->runnable = $execution;

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -34,7 +34,7 @@ class FileCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($cache->delete($key));
         $this->assertNull($cache->get($key));
         $this->assertTrue($cache->flush());
-        $this->assertFileDoesNotExist($path);
+        $this->assertFalse(file_exists($path));
     }
 
     /**

--- a/tests/PipeQueueTest.php
+++ b/tests/PipeQueueTest.php
@@ -23,6 +23,13 @@ class PipeQueueTest extends \PHPUnit\Framework\TestCase
 		$queue->remove();
     }
 
+	public function testGetFromEmptyQueue()
+	{
+		$queue = new \Jenner\SimpleFork\Queue\PipeQueue();
+		$this->assertNull($queue->get());
+		$queue->remove();
+	}
+
 	public function testValueTooLong()
 	{
 		$memory_limit = ini_get('memory_limit');

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -115,6 +115,42 @@ class ProcessTest extends \PHPUnit\Framework\TestCase
         new \Jenner\SimpleFork\Process("abc");
     }
 
+    public function testGetPid(): void
+    {
+        $process = new \Jenner\SimpleFork\Process(function () {
+            usleep(100000);
+        });
+        $this->assertNull($process->getPid());
+        $process->start();
+        $this->assertIsInt($process->getPid());
+        $this->assertGreaterThan(0, $process->getPid());
+        $process->wait();
+    }
+
+    public function testName(): void
+    {
+        $process = new \Jenner\SimpleFork\Process(function () {}, 'my-process');
+        $this->assertEquals('my-process', $process->name());
+
+        $process->name('renamed');
+        $this->assertEquals('renamed', $process->name());
+    }
+
+    public function testIsStartedAndIsStopped(): void
+    {
+        $process = new \Jenner\SimpleFork\Process(function () {
+            usleep(100000);
+        });
+        $this->assertFalse($process->isStarted());
+        $this->assertFalse($process->isStopped());
+
+        $process->start();
+        $this->assertTrue($process->isStarted());
+
+        $process->wait();
+        $this->assertTrue($process->isStopped());
+    }
+
 }
 
 class MyThread extends \Jenner\SimpleFork\Process

--- a/tests/SemaphoreTest.php
+++ b/tests/SemaphoreTest.php
@@ -76,6 +76,15 @@ class SemaphoreTest extends \PHPUnit\Framework\TestCase
         $this->lock->acquire(false);
         $this->lock->release();
 
+        $this->assertTrue($this->lock->remove());
+    }
+
+    public function testRemoveAlreadyRemovedSemaphore()
+    {
+        $this->lock->acquire(false);
+        $this->lock->release();
+        $this->lock->remove();
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("can not remove a empty semaphore resource");
         $this->lock->remove();


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to CI matrix
- Streamline CI: replace Docker-based actions with direct composer/phpunit CLI calls
- Run code coverage only on PHP 8.5 (other matrix jobs skip Xdebug for speed)
- Trigger CI on push to master + all pull requests (no duplicate runs)
- Bump actions/checkout to v4, codecov-action to v4
- Install PHP extensions via setup-php instead of phpunit action
- Fix implicit nullable parameter deprecation in `Process::__construct()` for PHP 8.5
- Fix `Semaphore::remove()` to work on both PHP 7 and 8 using `sem_remove()`
- Replace `assertFileDoesNotExist()` with PHPUnit 8.5-compatible alternative
- Add tests for `Process::getPid()`, `name()`, `isStarted()`, `isStopped()`
- Add tests for `PipeQueue` empty read and `Semaphore` double-remove

## Test plan
- [x] Verify all 9 PHP version matrix jobs pass
- [x] Verify coverage is generated and uploaded only for PHP 8.5
- [x] Verify no duplicate CI runs on PRs